### PR TITLE
Updating rpio version to allow Raspberry Pi 4 models to use this library!

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "binary-pixel-map": "^1.2.1",
-    "rpio": "^0.9.23"
+    "rpio": "^2.2.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.0",


### PR DESCRIPTION
It would be great to use this module with newer raspberry pi's, updating rpio doesn't seem to have any affects to this module.